### PR TITLE
Check SourceSet name instead of identity

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -227,9 +227,8 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
             }
         });
 
-        final IdeaModel idea = project.getExtensions().findByType(IdeaModel.class);
-
         if (runConfig.getMods().isEmpty()) {
+            final IdeaModel idea = project.getExtensions().findByType(IdeaModel.class);
             return getIdeaPathsForSourceset(project, idea, "production", null);
         } else {
 
@@ -237,7 +236,9 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
                     .map(modConfig -> {
                         return modConfig.getSources().stream().flatMap(source -> {
                             String outName = source.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME) ? "production" : source.getName();
-                            return getIdeaPathsForSourceset(sourceSetsToProjects.getOrDefault(source, project), idea, outName, modConfig.getName());
+                            final Project sourceSetProject = sourceSetsToProjects.getOrDefault(source, project);
+                            final IdeaModel ideaModel = sourceSetProject.getExtensions().findByType(IdeaModel.class);
+                            return getIdeaPathsForSourceset(sourceSetProject, ideaModel, outName, modConfig.getName());
                         });
                     })
                     .flatMap(Function.identity());
@@ -250,7 +251,7 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
         try
         {
             String outputPath = idea != null
-                    ? idea.getProject().getPathFactory().path("$PROJECT_DIR$").getCanonicalUrl()
+                    ? idea.getModule().getPathFactory().path("$MODULE_DIR$").getCanonicalUrl()
                     : project.getProjectDir().getCanonicalPath();
 
             ideaResources = Paths.get(outputPath, "out", outName, "resources").toFile().getCanonicalPath();

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -24,9 +24,7 @@ import net.minecraftforge.gradle.common.util.RunConfig;
 import net.minecraftforge.gradle.common.util.Utils;
 
 import org.gradle.api.Project;
-import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -218,9 +216,6 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
     private static Stream<String> mapModClassesToIdea(@Nonnull final Project project, @Nonnull final RunConfig runConfig) {
         final IdeaModel idea = project.getExtensions().findByType(IdeaModel.class);
 
-        JavaPluginExtension javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
-        SourceSetContainer sourceSets = javaPlugin.getSourceSets();
-        final SourceSet main = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME);
         if (runConfig.getMods().isEmpty()) {
             return getIdeaPathsForSourceset(project, idea, "production", null);
         } else {
@@ -228,7 +223,7 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
             return runConfig.getMods().stream()
                     .map(modConfig -> {
                         return modConfig.getSources().stream().flatMap(source -> {
-                            String outName = source == main ? "production" : source.getName();
+                            String outName = source.getName().equals(SourceSet.MAIN_SOURCE_SET_NAME) ? "production" : source.getName();
                             return getIdeaPathsForSourceset(project, idea, outName, modConfig.getName());
                         });
                     })


### PR DESCRIPTION
This fixes an issue where the main source set from another project
doesn't get the 'production' special-case, because it is a different
instance from the main source set of this project.